### PR TITLE
heroku prep

### DIFF
--- a/database/db_connection.js
+++ b/database/db_connection.js
@@ -1,7 +1,7 @@
 const { Pool } = require('pg')
 const url = require('url')
 
-require('env2')('./config.env')
+if (process.env.NODE_ENV !== 'production') require('env2')('./config.env')
 
 if (!process.env.DB_URL) {
   throw new Error('Environment variable DB_URL must be set')

--- a/src/server.js
+++ b/src/server.js
@@ -9,7 +9,8 @@ const dateFormat = require('dateformat')
 const cookieParser = require('cookie-parser')
 const { formatEvents } = require('./helpers.js')
 
-require('env2')('./config.env')
+if (process.env.NODE_ENV !== 'production') require('env2')('./config.env')
+
 const server = express()
 
 server.use(express.static(path.join(__dirname, '../public')))

--- a/src/start.js
+++ b/src/start.js
@@ -1,5 +1,6 @@
 const server = require('./server.js')
+const port = process.env.PORT || 8080
 
-server.listen(8080, function () {
-  console.log('listening to port 8080!')
+server.listen(port, function () {
+  console.log(`server listening on port ${port}!`)
 })


### PR DESCRIPTION
#80 
make server use process.env.port
only use local config vars if not in production